### PR TITLE
Adds ability to hide notes from rich presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can also reconnect to discord rich presence via the `Reconnect to Discord` c
 
 - Updates your Discord Status with Obsidian info, **Vault Name** and/or **Current File Name**.
 - Allows you to customise what info is shown.
+- Current file name can be hidden by adding a folder to exclude in settings or by setting `discord: false` in the file's frontmatter.
 
 ### Settings
 
@@ -30,6 +31,8 @@ You can also reconnect to discord rich presence via the `Reconnect to Discord` c
 
 - Toggle whether or not to show **Current File Name**
 - Toggle whether or not to show the current file **extension**
+- Add folders to be excluded from showing their notes as the **Current File Name**
+  - A file can still be shown if the folder is excluded by setting `discord: true` in the file's frontmatter.
 
 #### Time Settings
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-discordrpc",
   "name": "Discord Rich Presence",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.",
   "author": "Luke Leppan",
   "authorUrl": "https://lukeleppan.com",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Luke Leppan",
   "license": "MIT",
   "devDependencies": {
+    "@popperjs/core": "^2.10.2",
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,6 +118,7 @@ export default class ObsidianDiscordRPC extends Plugin {
       });
       await this.setActivity(this.app.vault.getName(), null);
     } catch (error) {
+      console.error(error);
       this.setState(PluginState.disconnected);
       this.statusBar.displayState(this.getState(), this.settings.autoHideStatusBar);
       this.logger.log("Failed to connect to Discord", this.settings.showPopups);

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,6 +190,7 @@ export default class ObsidianDiscordRPC extends Plugin {
     }
   }
   async canShowFileName(file: TFile) {
+    if (!file) return false;
     if (this.settings.showCurrentFileName) return false;
     
     const frontmatter = await this.app.metadataCache.getFileCache(file)?.frontmatter;

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,10 +146,12 @@ export default class ObsidianDiscordRPC extends Plugin {
       }
 
       let fileName: string = "...";
-      if (file && this.settings.showFileExtension) {
-        fileName = file.basename + "." + file.extension;
-      } else {
-        fileName = file.basename;
+      if (file) {
+          if (this.settings.showFileExtension) {
+            fileName = file.basename + "." + file.extension;
+          } else {
+            fileName = file.basename;
+          }
       }
 
       let date: Date;

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,7 +165,9 @@ export default class ObsidianDiscordRPC extends Plugin {
         date = new Date();
       }
 
-      if (this.settings.showVaultName && await this.canShowFileName(file)) {
+      const canShowFileName = await this.canShowFileName(file);
+      console.log("this.settings.showVaultName && canShowFileName", this.settings.showVaultName && canShowFileName);
+      if (this.settings.showVaultName && canShowFileName) {
         await this.rpc.setActivity({
           details: `Editing ${fileName}`,
           state: `Vault: ${vault}`,
@@ -180,7 +182,7 @@ export default class ObsidianDiscordRPC extends Plugin {
           largeImageKey: "logo",
           largeImageText: "Obsidian",
         });
-      } else if (await this.canShowFileName(file)) {
+      } else if (canShowFileName) {
         await this.rpc.setActivity({
           details: `Editing ${fileName}`,
           startTimestamp: date,
@@ -197,7 +199,7 @@ export default class ObsidianDiscordRPC extends Plugin {
     }
   }
   async canShowFileName(file: TFile) {
-      console.log("🚀 ~ file: main.ts ~ line 197 ~ file", file);
+    console.log("🚀 ~ file: main.ts ~ line 197 ~ file", file);
     if (!file) return false;
     console.log("🚀 ~ file: main.ts ~ line 199 ~ this.settings.showCurrentFileName", this.settings.showCurrentFileName);
     if (!this.settings.showCurrentFileName) return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,10 @@ export default class ObsidianDiscordRPC extends Plugin {
 
     this.settings = (await this.loadData()) || new DiscordRPCSettings();
 
+    if (!this.settings.exclude) {
+        this.settings.exclude = [];
+    }
+
     this.registerEvent(
       this.app.workspace.on("file-open", this.onFileOpen, this)
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,13 +193,17 @@ export default class ObsidianDiscordRPC extends Plugin {
     }
   }
   async canShowFileName(file: TFile) {
+      console.log("🚀 ~ file: main.ts ~ line 197 ~ file", file);
     if (!file) return false;
-    if (this.settings.showCurrentFileName) return false;
+    console.log("🚀 ~ file: main.ts ~ line 199 ~ this.settings.showCurrentFileName", this.settings.showCurrentFileName);
+    if (!this.settings.showCurrentFileName) return false;
     
     const frontmatter = await this.app.metadataCache.getFileCache(file)?.frontmatter;
+    console.log("🚀 ~ file: main.ts ~ line 203 ~ frontmatter && in frontmatter", frontmatter && "discord" in frontmatter);
     if (frontmatter && "discord" in frontmatter) return frontmatter.discord;
 
-    if (this.settings.exclude.some(path => new RegExp(`^${path}`).test(file.path))) return false;
+    console.log("🚀 ~ file: main.ts ~ line 206 ~ this.settings.exclude.some(path => new RegExp(`^${path}`).test(file.path))", this.settings.exclude.some(path => new RegExp(`^${path}`).test(file.path)));
+    if (this.settings.exclude.length && this.settings.exclude.some(path => new RegExp(`^${path}`).test(file.path))) return false;
 
     return true;
   }

--- a/src/settings/folder.ts
+++ b/src/settings/folder.ts
@@ -1,0 +1,83 @@
+import {
+    TFolder,
+    TextComponent,
+    CachedMetadata,
+    App,
+    FuzzyMatch
+} from "obsidian";
+import { SuggestionModal } from "./suggester";
+
+export class FolderSuggestionModal extends SuggestionModal<TFolder> {
+    text: TextComponent;
+    cache: CachedMetadata;
+    folders: TFolder[];
+    folder: TFolder;
+    constructor(app: App, input: TextComponent, items: TFolder[]) {
+        super(app, input.inputEl, items);
+        this.folders = [...items];
+        this.text = input;
+
+        this.inputEl.addEventListener("input", () => this.getFolder());
+    }
+    getFolder() {
+        const v = this.inputEl.value,
+            folder = this.app.vault.getAbstractFileByPath(v);
+        if (folder == this.folder) return;
+        if (!(folder instanceof TFolder)) return;
+        this.folder = folder;
+
+        this.onInputChanged();
+    }
+    getItemText(item: TFolder) {
+        return item.path;
+    }
+    onChooseItem(item: TFolder) {
+        this.text.setValue(item.path);
+        this.folder = item;
+    }
+    selectSuggestion({ item }: FuzzyMatch<TFolder>) {
+        let link = item.path;
+
+        this.text.setValue(link);
+        this.onClose();
+
+        this.close();
+    }
+    renderSuggestion(result: FuzzyMatch<TFolder>, el: HTMLElement) {
+        let { item, match: matches } = result || {};
+        let content = el.createDiv({
+            cls: "suggestion-content"
+        });
+        if (!item) {
+            content.setText(this.emptyStateText);
+            content.parentElement.addClass("is-selected");
+            return;
+        }
+
+        let pathLength = item.path.length - item.name.length;
+        const matchElements = matches.matches.map((m) => {
+            return createSpan("suggestion-highlight");
+        });
+        for (let i = pathLength; i < item.path.length; i++) {
+            let match = matches.matches.find((m) => m[0] === i);
+            if (match) {
+                let element = matchElements[matches.matches.indexOf(match)];
+                content.appendChild(element);
+                element.appendText(item.path.substring(match[0], match[1]));
+
+                i += match[1] - match[0] - 1;
+                continue;
+            }
+
+            content.appendText(item.path[i]);
+        }
+        el.createDiv({
+            cls: "suggestion-note",
+            text: item.path
+        });
+    }
+
+    getItems() {
+        return this.folders;
+    }
+}

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -32,8 +32,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
           plugin.setActivity(
             this.app.vault.getName(),
-            plugin.currentFile.basename,
-            plugin.currentFile.extension
+            plugin.currentFile
           );
         })
       );
@@ -50,8 +49,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
           plugin.setActivity(
             this.app.vault.getName(),
-            plugin.currentFile.basename,
-            plugin.currentFile.extension
+            plugin.currentFile
           );
         })
       );
@@ -75,8 +73,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
             plugin.setActivity(
               this.app.vault.getName(),
-              plugin.currentFile.basename,
-              plugin.currentFile.extension
+              plugin.currentFile
             );
           })
       );
@@ -93,8 +90,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
             plugin.setActivity(
               this.app.vault.getName(),
-              plugin.currentFile.basename,
-              plugin.currentFile.extension
+              plugin.currentFile
             );
           })
       );
@@ -102,7 +98,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
     let text: TextComponent, extra: ExtraButtonComponent;
     new Setting(containerEl).setName("Exclude Folders").setDesc("Select folders to exclude from displaying.").addText(t => {
         text = t;
-        let folders = this.app.vault.getAllLoadedFiles().filter((f) => f instanceof TFolder && plugin.settings.exclude.includes(f.path));
+        let folders = this.app.vault.getAllLoadedFiles().filter((f) => f instanceof TFolder && !plugin.settings.exclude.includes(f.path));
         const modal = new FolderSuggestionModal(plugin.app, text, (folders as TFolder[]));
         modal.onClose = () => {
             if (!text.inputEl.value) {
@@ -142,8 +138,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
           plugin.setActivity(
             this.app.vault.getName(),
-            plugin.currentFile.basename,
-            plugin.currentFile.extension
+            plugin.currentFile
           );
         });
       });
@@ -161,8 +156,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
           plugin.setActivity(
             this.app.vault.getName(),
-            plugin.currentFile.basename,
-            plugin.currentFile.extension
+            plugin.currentFile
           );
         });
       });
@@ -180,8 +174,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
           plugin.setActivity(
             this.app.vault.getName(),
-            plugin.currentFile.basename,
-            plugin.currentFile.extension
+            plugin.currentFile
           );
         });
       });
@@ -203,8 +196,7 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
 
           plugin.setActivity(
             this.app.vault.getName(),
-            plugin.currentFile.basename,
-            plugin.currentFile.extension
+            plugin.currentFile
           );
         })
       );

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -7,6 +7,7 @@ export class DiscordRPCSettings {
   useLoadedTime: boolean = false;
   connectOnStart: boolean = true;
   autoHideStatusBar: boolean = true;
+  exclude: string[] = []
 }
 
 export enum PluginState {

--- a/src/settings/suggester.ts
+++ b/src/settings/suggester.ts
@@ -1,0 +1,237 @@
+import {
+    App,
+    FuzzyMatch,
+    FuzzySuggestModal,
+    Scope,
+    SuggestModal
+} from "obsidian";
+import { createPopper, Instance as PopperInstance } from "@popperjs/core";
+declare module "obsidian" {
+    interface App {
+        keymap: {
+            pushScope(scope: Scope): void;
+            popScope(scope: Scope): void;
+        };
+    }
+}
+class Suggester<T> {
+    owner: SuggestModal<T>;
+    items: T[];
+    suggestions: HTMLDivElement[];
+    selectedItem: number;
+    containerEl: HTMLElement;
+    constructor(
+        owner: SuggestModal<T>,
+        containerEl: HTMLElement,
+        scope: Scope
+    ) {
+        this.containerEl = containerEl;
+        this.owner = owner;
+        containerEl.on(
+            "click",
+            ".suggestion-item",
+            this.onSuggestionClick.bind(this)
+        );
+        containerEl.on(
+            "mousemove",
+            ".suggestion-item",
+            this.onSuggestionMouseover.bind(this)
+        );
+
+        scope.register([], "ArrowUp", () => {
+            this.setSelectedItem(this.selectedItem - 1, true);
+            return false;
+        });
+
+        scope.register([], "ArrowDown", () => {
+            this.setSelectedItem(this.selectedItem + 1, true);
+            return false;
+        });
+
+        scope.register([], "Enter", (evt) => {
+            this.useSelectedItem(evt);
+            return false;
+        });
+
+        scope.register([], "Tab", (evt) => {
+            this.chooseSuggestion(evt);
+            return false;
+        });
+    }
+    chooseSuggestion(evt: KeyboardEvent) {
+        if (!this.items || !this.items.length) return;
+        const currentValue = this.items[this.selectedItem];
+        if (currentValue) {
+            this.owner.onChooseSuggestion(currentValue, evt);
+        }
+    }
+    onSuggestionClick(event: MouseEvent, el: HTMLDivElement): void {
+        event.preventDefault();
+        if (!this.suggestions || !this.suggestions.length) return;
+
+        const item = this.suggestions.indexOf(el);
+        this.setSelectedItem(item, false);
+        this.useSelectedItem(event);
+    }
+
+    onSuggestionMouseover(event: MouseEvent, el: HTMLDivElement): void {
+        if (!this.suggestions || !this.suggestions.length) return;
+        const item = this.suggestions.indexOf(el);
+        this.setSelectedItem(item, false);
+    }
+    empty() {
+        this.containerEl.empty();
+    }
+    setSuggestions(items: T[]) {
+        this.containerEl.empty();
+        const els: HTMLDivElement[] = [];
+
+        items.forEach((item) => {
+            const suggestionEl = this.containerEl.createDiv("suggestion-item");
+            this.owner.renderSuggestion(item, suggestionEl);
+            els.push(suggestionEl);
+        });
+        this.items = items;
+        this.suggestions = els;
+        this.setSelectedItem(0, false);
+    }
+    useSelectedItem(event: MouseEvent | KeyboardEvent) {
+        if (!this.items || !this.items.length) return;
+        const currentValue = this.items[this.selectedItem];
+        if (currentValue) {
+            this.owner.selectSuggestion(currentValue, event);
+        }
+    }
+    wrap(value: number, size: number): number {
+        return ((value % size) + size) % size;
+    }
+    setSelectedItem(index: number, scroll: boolean) {
+        const nIndex = this.wrap(index, this.suggestions.length);
+        const prev = this.suggestions[this.selectedItem];
+        const next = this.suggestions[nIndex];
+
+        if (prev) prev.removeClass("is-selected");
+        if (next) next.addClass("is-selected");
+
+        this.selectedItem = nIndex;
+
+        if (scroll) {
+            next.scrollIntoView(false);
+        }
+    }
+}
+
+export abstract class SuggestionModal<T> extends FuzzySuggestModal<T> {
+    items: T[] = [];
+    suggestions: HTMLDivElement[];
+    popper: PopperInstance;
+    scope: Scope = new Scope();
+    suggester: Suggester<FuzzyMatch<T>>;
+    suggestEl: HTMLDivElement;
+    promptEl: HTMLDivElement;
+    emptyStateText: string = "No match found";
+    limit: number = 100;
+    shouldNotOpen: boolean;
+    constructor(app: App, inputEl: HTMLInputElement, items: T[]) {
+        super(app);
+        this.inputEl = inputEl;
+        this.items = items;
+
+        this.suggestEl = createDiv("suggestion-container");
+
+        this.contentEl = this.suggestEl.createDiv("suggestion");
+
+        this.suggester = new Suggester(this, this.contentEl, this.scope);
+
+        this.scope.register([], "Escape", this.onEscape.bind(this));
+
+        this.inputEl.addEventListener("input", this.onInputChanged.bind(this));
+        this.inputEl.addEventListener("focus", this.onFocus.bind(this));
+        this.inputEl.addEventListener("blur", this.close.bind(this));
+        this.suggestEl.on(
+            "mousedown",
+            ".suggestion-container",
+            (event: MouseEvent) => {
+                event.preventDefault();
+            }
+        );
+    }
+    empty() {
+        this.suggester.empty();
+    }
+    onInputChanged(): void {
+        if (this.shouldNotOpen) return;
+        const inputStr = this.modifyInput(this.inputEl.value);
+        const suggestions = this.getSuggestions(inputStr);
+        if (suggestions.length > 0) {
+            this.suggester.setSuggestions(suggestions.slice(0, this.limit));
+        } else {
+            this.onNoSuggestion();
+        }
+        this.open();
+    }
+    onFocus(): void {
+        this.shouldNotOpen = false;
+        this.onInputChanged();
+    }
+    modifyInput(input: string): string {
+        return input;
+    }
+    onNoSuggestion() {
+        this.empty();
+        this.renderSuggestion(
+            null,
+            this.contentEl.createDiv("suggestion-item")
+        );
+    }
+    open(): void {
+        // TODO: Figure out a better way to do this. Idea from Periodic Notes plugin
+        this.app.keymap.pushScope(this.scope);
+
+        document.body.appendChild(this.suggestEl);
+        this.popper = createPopper(this.inputEl, this.suggestEl, {
+            placement: "bottom-start",
+            modifiers: [
+                {
+                    name: "offset",
+                    options: {
+                        offset: [0, 10]
+                    }
+                },
+                {
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: ["top"]
+                    }
+                }
+            ]
+        });
+    }
+
+    onEscape(): void {
+        this.close();
+        this.shouldNotOpen = true;
+    }
+    close(): void {
+        // TODO: Figure out a better way to do this. Idea from Periodic Notes plugin
+        this.app.keymap.popScope(this.scope);
+
+        this.suggester.setSuggestions([]);
+        if (this.popper) {
+            this.popper.destroy();
+        }
+
+        this.suggestEl.detach();
+    }
+    createPrompt(prompts: HTMLSpanElement[]) {
+        if (!this.promptEl)
+            this.promptEl = this.suggestEl.createDiv("prompt-instructions");
+        let prompt = this.promptEl.createDiv("prompt-instruction");
+        for (let p of prompts) {
+            prompt.appendChild(p);
+        }
+    }
+    abstract onChooseItem(item: T, evt: MouseEvent | KeyboardEvent): void;
+    abstract getItemText(arg: T): string;
+    abstract getItems(): T[];
+}


### PR DESCRIPTION
Close #4 

This PR adds a setting that allows users to add folder paths to be excluded from showing note titles.

It also adds the ability to set `discord: true/false` in frontmatter to hide/show that note.