### PR TITLE
Add connection timer/status bar stopwatch

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ export default class ObsidianDiscordRPC extends Plugin {
     );
 
     this.registerInterval(window.setInterval(async () => {
-      if (this.getState() == PluginState.connected){
+      if (this.settings.showConnectionTimer && this.getState() == PluginState.connected){
         this.statusBar.displayTimer(this.settings.useLoadedTime ? this.loadedTime : this.lastSetTime);
       }
     }, 500));

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ export default class ObsidianDiscordRPC extends Plugin {
   public logger: Logger = new Logger();
   public currentFile: TFile;
   public loadedTime: Date;
+  public lastSetTime: Date;
 
   setState(state: PluginState) {
     this.state = state;
@@ -42,7 +43,7 @@ export default class ObsidianDiscordRPC extends Plugin {
 
     this.registerInterval(window.setInterval(async () => {
       if (this.getState() == PluginState.connected){
-        this.statusBar.displayTimer(this.loadedTime);
+        this.statusBar.displayTimer(this.settings.useLoadedTime ? this.loadedTime : this.lastSetTime);
       }
     }, 500));
 
@@ -105,7 +106,8 @@ export default class ObsidianDiscordRPC extends Plugin {
 
   async connectDiscord(): Promise<void> {
     this.loadedTime = new Date();
-    
+    this.lastSetTime = new Date();
+
     this.rpc = new Client({
       transport: "ipc",
     });
@@ -165,6 +167,7 @@ export default class ObsidianDiscordRPC extends Plugin {
       } else {
         date = new Date();
       }
+      this.lastSetTime = date;
 
       if (this.settings.showVaultName && this.settings.showCurrentFileName) {
         await this.rpc.setActivity({

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,12 @@ export default class ObsidianDiscordRPC extends Plugin {
       this.app.workspace.on("file-open", this.onFileOpen, this)
     );
 
+    this.registerInterval(window.setInterval(async () => {
+      if (this.getState() == PluginState.connected){
+        this.statusBar.displayTimer(this.loadedTime);
+      }
+    }, 500));
+
     this.registerDomEvent(statusBarEl, "click", async () => {
       if (this.getState() == PluginState.disconnected) {
         await this.connectDiscord();

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -135,6 +135,26 @@ export class DiscordRPCSettingsTab extends PluginSettingTab {
           );
         });
       });
+    
+      new Setting(containerEl)
+      .setName("Show Connected Time")
+      .setDesc(
+        "Show time spent editing file or time connected to Discord in the status bar."
+      )
+      .addToggle((boolean) => {
+        boolean.setValue(plugin.settings.showConnectionTimer).onChange((value) => {
+          plugin.settings.showConnectionTimer = value;
+          plugin.saveData(plugin.settings);
+
+          plugin.setActivity(
+            this.app.vault.getName(),
+            plugin.currentFile.basename,
+            plugin.currentFile.extension
+          );
+          // needed to make timer disappear, otherwise it will freeze
+          plugin.statusBar.displayState(plugin.getState(), plugin.settings.autoHideStatusBar);
+        });
+      });
 
     containerEl.createEl("h3", { text: "Startup Settings" });
     new Setting(containerEl)

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,6 +1,7 @@
 export class DiscordRPCSettings {
   showVaultName: boolean = true;
   showCurrentFileName: boolean = true;
+  showConnectionTimer: boolean = false;
   showPopups: boolean = true;
   customVaultName: string = "";
   showFileExtension: boolean = false;

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -1,4 +1,6 @@
 import { PluginState } from "./settings/settings";
+import { moment } from 'obsidian';
+import type { Moment } from 'moment';
 
 export class StatusBar {
   private statusBarEl: HTMLElement;
@@ -21,6 +23,10 @@ export class StatusBar {
     }
   }
 
+  displayTimer(loadedTime: Date) {
+    this.statusBarEl.setText(`\u{1F30D} ${StatusBar.millisecsToString(new Date().getTime() - loadedTime.getTime())}`);
+  }
+
   displayConnected(timeout: number) {
     this.statusBarEl.setText(`\u{1F30D} Connected to Discord`);
 
@@ -33,5 +39,20 @@ export class StatusBar {
         this.statusBarEl.setText(`\u{1F30D}`);
       }, 5000);
     }
+  }
+
+  /* Returns [HH:]mm:ss on the stopwatch
+  https://github.com/grassbl8d/flexible-pomo-obsidian/blob/ae037e3710866863c5397f42af06c5540a807b10/src/timer.ts#L475
+  */
+  static millisecsToString(millisecs: number): string {
+    let formattedCountDown: string;
+
+    if (millisecs >= 60 * 60 * 1000) { /* >= 1 hour*/
+        formattedCountDown = moment.utc(millisecs).format('HH:mm:ss');
+    } else {
+        formattedCountDown = moment.utc(millisecs).format('mm:ss');
+    }
+
+    return formattedCountDown.toString();
   }
 }


### PR DESCRIPTION
I would often connect to Discord when starting a writing session in earnest, and while the helpful daily word count tracking in the Better Word Count plugin kept track of my progress in the status bar, I would end up checking my own Discord status to see how long I had spent writing.

Well, constantly tab between Discord and Obsidian no more! This PR adds a stopwatch to the status bar indicating how long the app has been connected to Discord:

![image](https://user-images.githubusercontent.com/45076643/169739726-ade1028e-1e40-425c-acf9-6910aacc1d7e.png)

A new setting is added, Show Connected Time, that enables or disables this little stopwatch. The time displayed on it respects the Use Obsidian Total Time setting: with it enabled, it displays the total time connected; with it disabled, it displays the time spent editing the current file.

Oddly, a simple status bar stopwatch doesn't exist anywhere in the community plugins (we have various pomodoro timers, and a sidebar stopwatch, but no status bar stopwatch), so consider this the first one!

(as an aside: my first series of pushed commits ended up with a ton of line ending errors (see ac90afd), which took a very long time and was very annoying to fix)